### PR TITLE
* babel-polyfill 转向 babel-(plugin-transform)-runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,7 @@
     "async-to-bluebird"
   ],
   "plugins": [
+    "transform-runtime",
     "transform-decorators-legacy"
   ]
 }

--- a/example/index.js
+++ b/example/index.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-constant-condition */
-import 'babel-polyfill'
 import 'should'
 import co from 'co'
 import Nixe from '../src/Nixe'

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-eslint": "^5.0.0",
     "babel-loader": "^6.2.3",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-runtime": "^6.7.5",
     "babel-preset-async-to-bluebird": "^1.0.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
@@ -27,7 +28,7 @@
     "which": "^1.2.4"
   },
   "dependencies": {
-    "babel-polyfill": "^6.5.0",
+    "babel-runtime": "^5.8.38",
     "bluebird": "^3.3.1",
     "co": "^4.6.0",
     "tiny-ipc": "^0.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,2 @@
 
-import 'babel-polyfill'
 export * from './Nixe'

--- a/src/nw-install-main.js
+++ b/src/nw-install-main.js
@@ -1,10 +1,3 @@
 
-// 容错 babel-polyfill要求单例
-try {
-  require('babel-polyfill')
-} catch (err) {
-  // ignore
-}
-
 require('./runner')
 require('./preload')

--- a/src/nw-install-web.js
+++ b/src/nw-install-web.js
@@ -1,10 +1,3 @@
 
-// 容错 babel-polyfill要求单例
-try {
-  require('babel-polyfill')
-} catch (err) {
-  // ignore
-}
-
 // require('./runner')
 require('./preload')

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,5 @@
 
 import { install } from 'mocha-generators'
-import 'babel-polyfill'
 // import './example'
 // import './electron'
 // import './Nixe'


### PR DESCRIPTION
理由: 前者会污染全局 后者则更适合library/tool
http://babeljs.io/docs/plugins/transform-runtime/
